### PR TITLE
Fix external links security

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
 
   <div class="content">
     <p><strong>Платформа открыта для сотрудничества: реклама, партнёрство, приём платежей через TON.</strong></p>
-    <a class="button" href="https://t.me/citizenkaz" target="_blank">Разместить рекламу</a>
+    <a class="button" href="https://t.me/citizenkaz" target="_blank" rel="noopener noreferrer">Разместить рекламу</a>
 
     <div class="ad-slot">
       <!-- Ad Block 1 -->
@@ -156,7 +156,7 @@
       <p>Вы можете разместить свой баннер, ссылку или партнёрскую интеграцию на этой площадке.</p>
       <p><strong>Стоимость размещения:</strong><br>
       от 3 000 ₸ / неделя или 10 000 ₸ / месяц</p>
-      <a class="button" href="https://t.me/citizenkaz" target="_blank">Оставить заявку</a>
+      <a class="button" href="https://t.me/citizenkaz" target="_blank" rel="noopener noreferrer">Оставить заявку</a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- prevent tab-nabbing by adding `rel="noopener noreferrer"` on external links

## Testing
- `grep -n "target="_blank"" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_68566bf80668832b88aaba66a400cd19